### PR TITLE
Fetch full headers instead of relying on customDBHeaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,31 +74,39 @@ Each node's type is designated by its `nodeType` property.
 
 Invalid parse trees will not be accepted by the API, due to verification against `schema.json`.
 
-Example:
+## Examples
 
-```json
-{
-  "nodeType": "concat",
-  "children": [
-    {
-      "nodeType": "literal",
-      "literalString": "Hello "
-    },
-    {
-      "nodeType": "regex",
-      "target": " <.*>$",
-      "replacement": "",
-      "flags": "",
-      "child": {
-        "nodeType": "header",
-        "headerName": "To"
+### Column Registration
+
+```javascript
+messenger.HeaderColumns.registerColumn(
+  "fromDomainColumn",
+  "From domain",
+  "Sort by from domain",
+  {
+    "nodeType": "concat",
+    "children": [
+      {
+        "nodeType": "literal",
+        "literalString": "Domain is "
+      },
+      {
+        "nodeType": "regex",
+        "pattern": ".*@([^>]*)>?$",
+        "replacement": "$1",
+        "flags": "",
+        "child": {
+          "nodeType": "header",
+          "headerName": "From",
+        }
       }
-    }
-  ]
-}
+    ]
+  },
+  false
+);
 ```
 
-## Example Add-ons
+### Full Add-ons
 
 * [X-Original-To Column](https://github.com/peterfab9845/original-to-column): Simple add-on adding a column with the content of the X-Original-To header.
 * [Header Columns](https://github.com/peterfab9845/tb-header-columns): More advanced add-on allowing users to create their own custom columns.

--- a/README.md
+++ b/README.md
@@ -44,8 +44,9 @@ Each node's type is designated by its `nodeType` property.
     - Properties:
         - `headerName` - Name of header
         - `headerIndex` (optional, default 0) - Which occurrence of a repeated header to take
-            - 0 = first occurrence, 1 = second, etc. Negatives wrap around (-1 = last occurrence, -2 = second-last, etc.)
-            - Has no effect if the `useDBHeaders` option is true. Behavior with repeated headers depends on TB version and has special cases.
+            - 0 = first occurrence, 1 = second, etc.
+            Negatives wrap around (-1 = last occurrence, -2 = second-last, etc.)
+            - Has no effect if the `useDBHeaders` option is true (see Options section)
 - `literal`
     - Returns literal string
     - Properties:
@@ -80,7 +81,11 @@ Invalid parse trees will not be accepted by the API, due to verification against
 The options object defines various configurations for the column, via the properties listed below.
 
 - `sortNumeric` (optional, default false) - If true, the column will be sorted by the numeric value of the final content; otherwise, it will be sorted alphanumerically.
-- `useDBHeaders` (optional, default false) - If true, only headers which are pre-parsed into the DB will be available. This provides a significant performance improvement, but has several important caveats (see below).
+- `useDBHeaders` (optional, default false) - If true, only headers which are pre-parsed into the DB will be available.
+This provides a significant performance improvement, but has several important caveats:
+    - The `customDBHeaders` preference (see following section) needs to be set in order to read most headers.
+    - The `headerIndex` property has no effect.
+    Behavior with repeated headers depends on TB version and has special cases.
 
 ### The `customDBHeaders` Preference
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Invalid parse trees will not be accepted by the API, due to verification against
 
 ### Options
 
-The options object defines various configurations for the column, as listed below.
+The options object defines various configurations for the column, via the properties listed below.
 
 - `sortNumeric` (optional, default false) - If true, the column will be sorted by the numeric value of the final content; otherwise, it will be sorted alphanumerically.
 - `useDBHeaders` (optional, default false) - If true, only headers which are pre-parsed into the DB will be available. This provides a significant performance improvement, but has several important caveats (see below).

--- a/README.md
+++ b/README.md
@@ -80,12 +80,11 @@ Invalid parse trees will not be accepted by the API, due to verification against
 The options object defines various configurations for the column, as listed below.
 
 - `sortNumeric` (optional, default false) - If true, the column will be sorted by the numeric value of the final content; otherwise, it will be sorted alphanumerically.
-- `useDBHeaders` (optional, default false) - If true, only headers which are pre-parsed into the DB will be available (see below). This provides a significant performance improvement at the cost of convenience.
+- `useDBHeaders` (optional, default false) - If true, only headers which are pre-parsed into the DB will be available. This provides a significant performance improvement, but has several important caveats (see below).
 
 ### The `customDBHeaders` Preference
 
-In order for the content of a non-default header to be parsed and recorded in the mail database, allowing it to be used with `useDBHeaders` set, that header must be present in the space-separated preference `mailnews.customDBHeaders` at the time the message is downloaded.
-This Experiment API does not manage the `customDBHeaders` preference.
+In order for the content of a non-default header to be parsed and recorded in the mail database by Thunderbird, allowing it to be used with `useDBHeaders` set, that header must be listed in the space-separated preference `mailnews.customDBHeaders` at the time the message is downloaded.
 
 If needed, new headers can be added to existing messages by running a repair operation on their containing folder (Folder Properties > Repair Folder).
 Note that this process may reset the folder's column layout and sort order.
@@ -106,6 +105,8 @@ Some possibly useful properties which may exist are:
 - `message-id` - message id string
 - `msgCharSet` - message charset
 - `numLines` - total message lines with headers, in hex
+
+NOTE: This Experiment API does not manage the `customDBHeaders` preference, and cannot make any guarantees regarding the default properties listed above.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Include the repository within your extension's `api` folder, and add the followi
 }
 ```
 
+Additionally, make sure to include the `messagesRead` permission in the `permissions` array.
+
 ## Usage
 
 ### API Functions
@@ -96,14 +98,6 @@ Example:
   ]
 }
 ```
-
-### The `customDBHeaders` Preference
-
-In order for the content of a particular header to be recorded in the mail database, that header must be present in the space-separated preference `mailnews.customDBHeaders` at the time the message is downloaded.
-If needed, the database for a folder can be rebuilt by selecting Folder Properties > Repair Folder.
-Note that this process may reset its column layout and sort order.
-
-This API does not manage this preference; for this purpose, it is currently recommended to use the [LegacyPrefs](https://github.com/thundernest/addon-developer-support/tree/master/auxiliary-apis/LegacyPrefs) experiment API.
 
 ## Example Add-ons
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Each node's type is designated by its `nodeType` property.
     - Returns raw header content
     - Properties:
         - `headerName` - Name of header
+        - `headerIndex` (optional, default 0) - Which occurrence of a repeated header to take. Negatives wrap around (-1 = last, -2 = second-last).
 - `literal`
     - Returns literal string
     - Properties:

--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ Include the repository within your extension's `api` folder, and add the followi
 }
 ```
 
-Additionally, make sure to include the `messagesRead` permission in the `permissions` array.
-
 ## Usage
 
 ### API Functions

--- a/implementation.js
+++ b/implementation.js
@@ -147,13 +147,19 @@
     async loadHeaders(id, win) {
       let msg = await messenger.messages.getFull(id);
       this.cache.set(id, msg.headers ?? {});
+      // Wait to update the view, because these requests come in bursts.
+      // User interaction (such as mousing over or scrolling the view) will also
+      // cause updates, so this delay is typically invisible.
       clearTimeout(this.timeouts.get(win));
       this.timeouts.set(win, setTimeout(function() {
+        // If at least one message in the given range is visible, then custom
+        // column values for all visible rows will be updated irrespective of
+        // the actual specified range.
+        // The range is automatically trimmed to visible rows, so just specify
+        // the whole thing to make sure we include something visible. Not sure
+        // how I'd find out which rows are visible on my own anyway.
         // nsMsgViewNotificationCode::changed == 2
-        // Starting at row 0, update 1 row.
-        // Despite only specifying a single row, this updates the contents of
-        // custom columns for all rows. Not sure how I'd know which are visible.
-        win.gDBView.NoteChange(0, 1, 2);
+        win.gDBView.NoteChange(0, win.gDBView.numMsgsInView - 1, 2);
       }, 200));
     }
   }

--- a/implementation.js
+++ b/implementation.js
@@ -97,7 +97,8 @@
         case "literal":
           return node.literalString;
         case "header":
-          return headers[node.headerName.toLowerCase()] ?? "";
+          // TODO add optional index property (replace the 0). at() allows -1 => last
+          return headers[node.headerName.toLowerCase()]?.at(0) ?? "";
         case "replace":
           if (node.replaceAll) {
             return this.parse(node.child, headers).replaceAll(node.target, node.replacement);

--- a/implementation.js
+++ b/implementation.js
@@ -16,7 +16,7 @@
       this.win = win;
       this.parseTree = parseTree;
       this.options = options;
-      // defaults - TODO potentially remove if schema can specify default values
+      // defaults
       this.options.sortNumeric ??= false;
       this.options.useDBHeaders ??= false;
     }
@@ -94,7 +94,7 @@
       if (this.options.useDBHeaders) {
         return this.parse(this.parseTree, aHdr);
       } else {
-        let headers = headerCache.getHeaders(aHdr, this.win); // false == pending
+        let headers = headerCache.getHeaders(aHdr, this.win); // null == pending
         return headers ? this.parse(this.parseTree, headers) : "";
       }
     }
@@ -112,7 +112,6 @@
             // headerSource == object of arrays of header content
             // at() instead of [] allows -1 => last
             return headerSource[node.headerName.toLowerCase()]?.at(node.headerIndex ?? 0) ?? "";
-            // TODO maybe remove this if the schema can give a default? ----------> ^^^^
           }
         case "replace":
           if (node.replaceAll) {
@@ -149,7 +148,7 @@
 
     getHeaders(aHdr, win) {
       if (!this.cache.has(aHdr)) {
-        this.cache.set(aHdr, false); // false = pending
+        this.cache.set(aHdr, null); // null = pending
         this.loadHeaders(aHdr, win); // asynchronous call
       }
       return this.cache.get(aHdr);
@@ -159,6 +158,7 @@
       let msg = await this.getMimeMessage(aHdr);
       let headers = this.convertMimeHeaders(msg);
       this.cache.set(aHdr, headers ?? {});
+      // TODO separate view refreshing from header cache
       // Don't update the view right away because these requests come in bursts.
       // User interaction (such as mousing over or scrolling the view) will also
       // cause updates, so this delay is typically invisible.

--- a/implementation.js
+++ b/implementation.js
@@ -341,6 +341,9 @@
     }
   }
 
+  var manager;
+  var headerCache;
+
   var createDBViewObserver = {
     observe(aMsgFolder, aTopic, aData) {
       manager.onCreateDBView();
@@ -352,9 +355,6 @@
       Services.obs.removeObserver(this, "MsgCreateDBView");
     }
   };
-
-  var manager;
-  var headerCache;
 
   class HeaderColumns extends ExtensionCommon.ExtensionAPI {
     // Construct an instance of our experiment; called once (per addon using the

--- a/implementation.js
+++ b/implementation.js
@@ -146,8 +146,8 @@
       // Don't update the view right away because these requests come in bursts.
       // User interaction (such as mousing over or scrolling the view) will also
       // cause updates, so this delay is typically invisible.
-      clearTimeout(this.timeouts.get(win));
-      this.timeouts.set(win, setTimeout(function() {
+      win.clearTimeout(this.timeouts.get(win));
+      this.timeouts.set(win, win.setTimeout(function() {
         // If at least one message in the given range is visible, then custom
         // column values for all visible rows will be updated irrespective of
         // the actual specified range.

--- a/implementation.js
+++ b/implementation.js
@@ -149,9 +149,10 @@
       this.cache.set(id, msg.headers ?? {});
       clearTimeout(this.timeouts.get(win));
       this.timeouts.set(win, setTimeout(function() {
-        // Update 1 row starting at row 0, for reason 2 (changed).
+        // nsMsgViewNotificationCode::changed == 2
+        // Starting at row 0, update 1 row.
         // Despite only specifying a single row, this updates the contents of
-        // custom columns for all rows.
+        // custom columns for all rows. Not sure how I'd know which are visible.
         win.gDBView.NoteChange(0, 1, 2);
       }, 200));
     }

--- a/implementation.js
+++ b/implementation.js
@@ -91,8 +91,8 @@
       return (this.win.gDBView.getFlagsAt(row) & MSG_VIEW_FLAG_DUMMY) != 0;
     }
     getText(aHdr) {
-      let value = headerCache.getHeaders(aHdr, this.win); // false == pending
-      return value ? this.parse(this.parseTree, value) : "";
+      let result = headerCache.getHeaders(aHdr, this.win); // false == pending
+      return result ? this.parse(this.parseTree, result) : "";
     }
     parse(node, headers) {
       // Recursively parse the tree to create the column content.

--- a/implementation.js
+++ b/implementation.js
@@ -97,8 +97,8 @@
         case "literal":
           return node.literalString;
         case "header":
-          // TODO add optional index property (replace the 0). at() allows -1 => last
-          return headers[node.headerName.toLowerCase()]?.at(0) ?? "";
+          // at() instead of [] allows -1 => last
+          return headers[node.headerName.toLowerCase()]?.at(node.headerIndex ?? 0) ?? "";
         case "replace":
           if (node.replaceAll) {
             return this.parse(node.child, headers).replaceAll(node.target, node.replacement);

--- a/implementation.js
+++ b/implementation.js
@@ -100,9 +100,9 @@
           return headers[node.headerName.toLowerCase()] ?? "";
         case "replace":
           if (node.replaceAll) {
-            return this.parse(node.child, headers).replace(node.target, node.replacement);
-          } else {
             return this.parse(node.child, headers).replaceAll(node.target, node.replacement);
+          } else {
+            return this.parse(node.child, headers).replace(node.target, node.replacement);
           }
         case "regex":
           let re = new RegExp(node.pattern, node.flags); // potential errors

--- a/implementation.js
+++ b/implementation.js
@@ -156,7 +156,7 @@
         // how I'd find out which rows are visible on my own anyway.
         // nsMsgViewNotificationCode::changed == 2
         win.gDBView.NoteChange(0, win.gDBView.numMsgsInView - 1, 2);
-      }, 200));
+      }, 100));
     }
 
     // https://searchfox.org/comm-central/source/mail/components/extensions/parent/ext-messages.js

--- a/implementation.js
+++ b/implementation.js
@@ -178,6 +178,8 @@
     // https://searchfox.org/comm-central/source/mail/components/extensions/parent/ext-messages.js
     // getMimeMessage(msgHdr)
     async getMimeMessage(msgHdr) {
+      // TODO NNTP messages not supported by MsgHdrToMimeMessage.
+      // Use MsgHdrToRawMessage, as in messages API (link above).
       return await new Promise(resolve => {
         MsgHdrToMimeMessage(
           msgHdr,

--- a/schema.json
+++ b/schema.json
@@ -135,6 +135,7 @@
             "optional": true,
             "description": "True if message DB properties should be used without fetching full headers."
           }
+        }
       }
     ],
     "functions": [

--- a/schema.json
+++ b/schema.json
@@ -120,6 +120,21 @@
             }
           }
         ]
+      },
+      {
+        "id": "options",
+        "type": "object",
+        "properties": {
+          "sortNumeric": {
+            "type": "boolean",
+            "optional": true,
+            "description": "True if the column should be sorted in numerical order."
+          },
+          "useDBHeaders": {
+            "type": "boolean",
+            "optional": true,
+            "description": "True if message DB properties should be used without fetching full headers."
+          }
       }
     ],
     "functions": [
@@ -151,9 +166,10 @@
             "description": "The tree defining how the column content should be created."
           },
           {
-            "name": "sortNumeric",
-            "type": "boolean",
-            "description": "True if the header should be sorted numerically."
+            "name": "options",
+            "type": "object",
+            "$ref": "options",
+            "description": "An object defining options for the column."
           }
         ]
       },

--- a/schema.json
+++ b/schema.json
@@ -30,6 +30,10 @@
               },
               "headerName": {
                 "type": "string"
+              },
+              "headerIndex": {
+                "type": "integer",
+                "optional": true
               }
             }
           },


### PR DESCRIPTION
Instead of setting the customDBHeaders pref so that we can access specific headers via `msgHdr.getStringProperty()`, fetch the full message headers.

This allows any header to be used, on pre-downloaded messages, without requiring a folder repair operation or any pref changes.